### PR TITLE
Close: #9 - Amélioration de l'API et de la récupération des datas côté client - Nouvelle méthode sur l'API et refacto d'une partie du store

### DIFF
--- a/api/graphql/resolvers/benchList.js
+++ b/api/graphql/resolvers/benchList.js
@@ -19,6 +19,14 @@ module.exports = {
       throw err
     }
   },
+  singleBench: async args => {
+    try {
+      const bench = await Bench.findById(args.benchId)
+      return bench
+    } catch (err) {
+      throw err
+    }
+  },
   createBench: async args => {
     const bench = new Bench({
       name: args.benchInput.name,

--- a/api/graphql/schema/index.graphql
+++ b/api/graphql/schema/index.graphql
@@ -28,15 +28,10 @@ module.exports = buildSchema(`
     title: String!,
     description: String!
   }
-
-  input SingleBenchInput {
-    benchId: ID!
-  }
   
-
   type RootQuery {
     benchList: [Bench!]!
-    singleBench(SingleBenchInput): Bench!
+    singleBench(benchId: ID!): Bench!
     petitionList: [Petition!]!
   }
 

--- a/api/graphql/schema/index.graphql
+++ b/api/graphql/schema/index.graphql
@@ -9,6 +9,12 @@ module.exports = buildSchema(`
     geolocation: [Float]!,
     hashTags: [String!]
   }
+
+  type Petition {
+    _id: ID!
+    title: String!,
+    description: String!,
+  }
   
   input BenchInput {
     name: String!
@@ -18,19 +24,19 @@ module.exports = buildSchema(`
     hashTags: [String!]
   }
 
-  type Petition {
-    _id: ID!
-    title: String!,
-    description: String!,
-  }
-
   input PetitionInput {
     title: String!,
     description: String!
   }
 
+  input SingleBenchInput {
+    benchId: ID!
+  }
+  
+
   type RootQuery {
     benchList: [Bench!]!
+    singleBench(SingleBenchInput): Bench!
     petitionList: [Petition!]!
   }
 

--- a/client/src/@types/index.d.ts
+++ b/client/src/@types/index.d.ts
@@ -1,14 +1,7 @@
 export type Coords = [number,number]
 
 export interface ApiBench {
-  name?: string,
-  description?: string,
-  lockedDescription?: string,
-  geolocation?: Coords
-}
-
-export interface ApiBenchTemp {
-  id?: number,
+  _id: string,
   name?: string,
   description?: string,
   lockedDescription?: string,
@@ -23,5 +16,4 @@ export interface queryApiBench {
 }
 
 export type ApiBenchReponseRoot =  Array<ApiBench>
-export type ApiBenchReponseRootTemp =  Array<ApiBenchTemp>
 export type QueryApiBenchReponse = queryApiBench

--- a/client/src/@types/index.d.ts
+++ b/client/src/@types/index.d.ts
@@ -16,4 +16,5 @@ export interface queryApiBench {
 }
 
 export type ApiBenchReponseRoot =  Array<ApiBench>
+export type ApiSingleBenchReponseRoot = ApiBench
 export type QueryApiBenchReponse = queryApiBench

--- a/client/src/@types/index.d.ts
+++ b/client/src/@types/index.d.ts
@@ -1,10 +1,18 @@
 export type Coords = [number,number]
 
 export interface ApiBench {
-  name: string,
-  description: string,
-  lockedDescription: string,
-  geolocation: Coords
+  name?: string,
+  description?: string,
+  lockedDescription?: string,
+  geolocation?: Coords
+}
+
+export interface ApiBenchTemp {
+  id?: number,
+  name?: string,
+  description?: string,
+  lockedDescription?: string,
+  geolocation?: Coords
 }
 
 export interface queryApiBench {
@@ -15,4 +23,5 @@ export interface queryApiBench {
 }
 
 export type ApiBenchReponseRoot =  Array<ApiBench>
+export type ApiBenchReponseRootTemp =  Array<ApiBenchTemp>
 export type QueryApiBenchReponse = queryApiBench

--- a/client/src/ApiClient/ApiClient.ts
+++ b/client/src/ApiClient/ApiClient.ts
@@ -6,6 +6,7 @@ class ApiClient {
     const query = `
     query {
       benchList{
+        _id
         ${args.name ? 'name' : ''}
         ${args.description ? 'description' : ''}
         ${args.lockedDescription ? 'lockedDescription' : ''}

--- a/client/src/ApiClient/ApiClient.ts
+++ b/client/src/ApiClient/ApiClient.ts
@@ -1,16 +1,31 @@
-import { ApiBenchReponseRoot, QueryApiBenchReponse } from "../@types";
+import { ApiBenchReponseRoot, QueryApiBenchReponse, ApiSingleBenchReponseRoot, ApiBench } from "../@types";
 
 class ApiClient {
 
-  private queryBenchList = (args: QueryApiBenchReponse) => {
+  private queryBenchList = (fieldsToFetch: QueryApiBenchReponse) => {
     const query = `
     query {
       benchList{
         _id
-        ${args.name ? 'name' : ''}
-        ${args.description ? 'description' : ''}
-        ${args.lockedDescription ? 'lockedDescription' : ''}
-        ${args.geolocation ? 'geolocation' : ''}
+        ${fieldsToFetch.name ? 'name' : ''}
+        ${fieldsToFetch.description ? 'description' : ''}
+        ${fieldsToFetch.lockedDescription ? 'lockedDescription' : ''}
+        ${fieldsToFetch.geolocation ? 'geolocation' : ''}
+      }
+    }
+    `
+    return query
+  }
+
+  private querySingleBench = (benchId: ApiBench["_id"], fieldsToFetch: QueryApiBenchReponse) => {
+    const query = `
+    query {
+      singleBench(benchId:"${benchId}") {
+        _id
+        ${fieldsToFetch.name ? 'name' : ''}
+        ${fieldsToFetch.description ? 'description' : ''}
+        ${fieldsToFetch.lockedDescription ? 'lockedDescription' : ''}
+        ${fieldsToFetch.geolocation ? 'geolocation' : ''}
       }
     }
     `
@@ -44,6 +59,35 @@ class ApiClient {
       })
 
     return benchList
+  }
+
+  public getSingleBench = async (benchID: ApiBench["_id"], fieldsToFetch: QueryApiBenchReponse): Promise<ApiSingleBenchReponseRoot> => {
+    let bench: ApiBench = {_id: ""}
+    const query = this.querySingleBench(benchID, fieldsToFetch)
+    const requestBody = {
+      query: query
+    }
+    await (fetch(`${process.env.REACT_APP_PATH_API}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(requestBody),
+    }))
+      .then(res => {
+        if (res.status !== 200 && res.status !== 201) {
+          throw Error('Failed')
+        }
+        return res.json()
+      })
+      .then(resData => {
+        bench = resData.data.singleBench
+      })
+      .catch(err => {
+        console.log(err)
+      })
+
+    return bench
   }
 
 }

--- a/client/src/components/debug/DebugPanel.tsx
+++ b/client/src/components/debug/DebugPanel.tsx
@@ -7,44 +7,52 @@ import './debugPanel.scss'
 
 const DebugPanel: FunctionComponent = () => {
 
-  const {benchListTemp, fetchBenchList} = Store
+  const { benchList, fetchBenchList } = Store
   const { debug } = DebugStore
 
-    const getInstallationList = async() => {
-      await fetchBenchList("nameGeo")
-    }
+  const queryName = async () => {
+    await fetchBenchList({ name: true })
+  }
 
-    const test = async() => {
-      await fetchBenchList("test")
-    }
+  const queryDesc = async () => {
+    await fetchBenchList({ description: true })
+  }
 
-    return (
-      <>
+  const queryGeoAndDesc = async () => {
+    await fetchBenchList({ geolocation: true, description: true })
+  }
+
+  return (
+    <>
       <DebugButton />
-      {debug && 
-      <div className="debug-panel">
-        <h2>Debug interface</h2>
-        <div>
-          <h3>Bench list</h3>
-          <ul>
-            {
-              benchListTemp.map((bench, index) => (
-                <li key={index}>
-                  {bench.name && <p>{bench.name}</p>}
-                  {bench.description && <p>{bench.description}</p>}
-                  {bench.lockedDescription && <p>{bench.lockedDescription}</p>}
-                  {bench.geolocation && bench.geolocation.map((item, index) => <p key={index}>{item}</p>)
-                  }
-                </li>
-              ))
-            }
-          </ul>
-        </div>
-        <button onClick={getInstallationList}>Query toutes les installation</button>
-        <button onClick={test}>Query toutes les installation</button>
-      </div>}
-      </>
-    )
+      {debug &&
+        <div className="debug-panel">
+          <h2>Debug interface</h2>
+          <div>
+            <h3>Bench list</h3>
+            <ul>
+              {
+                benchList.map((bench, index) => (
+                  <li key={index}>
+                    {bench._id && <p>{bench._id}</p>}
+                    {bench.name && <p>{bench.name}</p>}
+                    {bench.description && <p>{bench.description}</p>}
+                    {bench.lockedDescription && <p>{bench.lockedDescription}</p>}
+                    {bench.geolocation && <p>{bench.geolocation.map((item, index) => (
+                      <span key={index}>{item} </span>)
+                    )}</p>
+                    }
+                  </li>
+                ))
+              }
+            </ul>
+          </div>
+          <button onClick={queryName}>Query le nom des installations</button>
+          <button onClick={queryDesc}>Query la description</button>
+          <button onClick={queryGeoAndDesc}>Query la geoloc et la description</button>
+        </div>}
+    </>
+  )
 }
 
 export default observer(DebugPanel)

--- a/client/src/components/debug/DebugPanel.tsx
+++ b/client/src/components/debug/DebugPanel.tsx
@@ -7,19 +7,19 @@ import './debugPanel.scss'
 
 const DebugPanel: FunctionComponent = () => {
 
-  const { benchList, fetchBenchList } = Store
+  const { benchList, fetchBenchList, fetchSingleBench } = Store
   const { debug } = DebugStore
 
   const queryName = async () => {
     await fetchBenchList({ name: true })
   }
 
-  const queryDesc = async () => {
-    await fetchBenchList({ description: true })
-  }
-
   const queryGeoAndDesc = async () => {
     await fetchBenchList({ geolocation: true, description: true })
+  }
+
+  const queryOneBench = async () => {
+    await fetchSingleBench("5cad02bb1f4fddfe20225f18",{geolocation:true})
   }
 
   return (
@@ -48,8 +48,8 @@ const DebugPanel: FunctionComponent = () => {
             </ul>
           </div>
           <button onClick={queryName}>Query le nom des installations</button>
-          <button onClick={queryDesc}>Query la description</button>
           <button onClick={queryGeoAndDesc}>Query la geoloc et la description</button>
+          <button onClick={queryOneBench}>Query les infos d'un banc</button>
         </div>}
     </>
   )

--- a/client/src/components/debug/DebugPanel.tsx
+++ b/client/src/components/debug/DebugPanel.tsx
@@ -7,11 +7,15 @@ import './debugPanel.scss'
 
 const DebugPanel: FunctionComponent = () => {
 
-  const {benchList, fetchBenchList} = Store
+  const {benchListTemp, fetchBenchList} = Store
   const { debug } = DebugStore
 
     const getInstallationList = async() => {
-      await fetchBenchList({name:true, description: true, geolocation: true})
+      await fetchBenchList("nameGeo")
+    }
+
+    const test = async() => {
+      await fetchBenchList("test")
     }
 
     return (
@@ -24,7 +28,7 @@ const DebugPanel: FunctionComponent = () => {
           <h3>Bench list</h3>
           <ul>
             {
-              benchList.map((bench, index) => (
+              benchListTemp.map((bench, index) => (
                 <li key={index}>
                   {bench.name && <p>{bench.name}</p>}
                   {bench.description && <p>{bench.description}</p>}
@@ -37,6 +41,7 @@ const DebugPanel: FunctionComponent = () => {
           </ul>
         </div>
         <button onClick={getInstallationList}>Query toutes les installation</button>
+        <button onClick={test}>Query toutes les installation</button>
       </div>}
       </>
     )

--- a/client/src/components/map/MapManager.ts
+++ b/client/src/components/map/MapManager.ts
@@ -62,7 +62,7 @@ class MapManager {
   public setAllMarkers = (benchList: ApiBenchReponseRoot, map: mapboxgl.Map) => {
     const markers: mapboxgl.Marker[] = []
     benchList.map(bench => {
-      let marker = new mapboxgl.Marker().setLngLat(bench.geolocation).addTo(map)
+      let marker = new mapboxgl.Marker().setLngLat(bench.geolocation!).addTo(map)
       markers.push(marker)
     })
     return markers

--- a/client/src/components/map/ProtoMap.tsx
+++ b/client/src/components/map/ProtoMap.tsx
@@ -31,8 +31,8 @@ const ProtoMap: FunctionComponent = () => {
     map.current.addControl(directions.current);
 
     map.current.on('load', function () {
-      getInstallationList()
-      geolocate.current.trigger()
+      //getInstallationList()
+      //geolocate.current.trigger()
     })
 
     geolocate.current.on('geolocate', function (e: any) {

--- a/client/src/components/map/ProtoMap.tsx
+++ b/client/src/components/map/ProtoMap.tsx
@@ -20,7 +20,7 @@ const ProtoMap: FunctionComponent = () => {
   const [travelDistance, setTravelDistance] = useState()
 
   const getInstallationList = async () => {
-    await fetchBenchList({ name: true, description: true, geolocation: true })
+    await fetchBenchList("", { name: true, description: true, geolocation: true })
   }
 
   useEffect(() => {

--- a/client/src/components/map/ProtoMap.tsx
+++ b/client/src/components/map/ProtoMap.tsx
@@ -20,7 +20,7 @@ const ProtoMap: FunctionComponent = () => {
   const [travelDistance, setTravelDistance] = useState()
 
   const getInstallationList = async () => {
-    await fetchBenchList("", { name: true, description: true, geolocation: true })
+    await fetchBenchList({ name: true, description: true, geolocation: true })
   }
 
   useEffect(() => {

--- a/client/src/store/DebugStore.ts
+++ b/client/src/store/DebugStore.ts
@@ -1,7 +1,7 @@
 import { action, observable } from 'mobx'
 
 class DebugStore {
-    @observable debug = true
+    @observable debug = false
 
     @action public showDebug = () => {
         this.debug = true

--- a/client/src/store/DebugStore.ts
+++ b/client/src/store/DebugStore.ts
@@ -1,7 +1,7 @@
 import { action, observable } from 'mobx'
 
 class DebugStore {
-    @observable debug = false
+    @observable debug = true
 
     @action public showDebug = () => {
         this.debug = true

--- a/client/src/store/Store.ts
+++ b/client/src/store/Store.ts
@@ -1,38 +1,87 @@
 import { action, observable } from 'mobx'
-import ApiClient from '../ApiClient/ApiClient';
-import { ApiBenchReponseRoot, QueryApiBenchReponse } from '../@types';
+import { ApiBenchReponseRoot, QueryApiBenchReponse, ApiBenchReponseRootTemp, ApiBenchTemp } from '../@types';
 
 class Store {
-  @observable benchList:ApiBenchReponseRoot = []
+  @observable benchList: ApiBenchReponseRoot = []
+  @observable benchListTemp: ApiBenchReponseRoot = []
 
-  @action public fetchBenchList = async (fieldToFetch: QueryApiBenchReponse) => {
+  /**
+   * Recuperer des infos spécifiques
+   * Merge au tableau déjà existant dans le store =>
+   * Ajout des données récuperer sans écrasé les précédentes données
+   */
+
+  @action public fetchBenchList = async (dataToLoad?: string, fieldToFetch?: QueryApiBenchReponse) => {
     if (process.env.NODE_ENV === "development") {
+
+      const nameGeoData: ApiBenchReponseRootTemp = [
+        {
+          id: 1,
+          name: "Bench1",
+        },
+        {
+          id: 2,
+          name: "Bench2",
+        },
+        {
+          id: 3,
+          name: "Bench3",
+        }
+      ]
+
+      const descData: ApiBenchReponseRootTemp = [
+        {
+          id: 1,
+          description: "Desc1",
+        },
+        {
+          id: 2,
+          description: "Desc2",
+        },
+        {
+          id: 3,
+          description: "Desc3",
+        }
+      ]
+
+      let data: ApiBenchReponseRootTemp
+
+      dataToLoad === "nameGeo" ? data = nameGeoData : data = descData
+
+      const mergeById = (array1:ApiBenchReponseRootTemp, array2:ApiBenchReponseRootTemp) =>
+      array1.map(itm => ({
+          ...array2.find((item:any) => (item.id === itm.id) && item),
+          ...itm
+        }));
+
+      this.benchListTemp = mergeById(data, this.benchListTemp);
+
       this.benchList = [
         {
           name: "Bench1",
           description: "Desc1",
-          lockedDescription: "Locked",       
-          geolocation: [2.402,48.8787]
+          lockedDescription: "Locked",
+          geolocation: [2.402, 48.8787]
         },
         {
           name: "Bench2",
           description: "Desc2",
           lockedDescription: "Locked",
-          geolocation: [2.40764,48.87512]
+          geolocation: [2.40764, 48.87512]
         },
         {
           name: "Bench3",
           description: "Desc3",
           lockedDescription: "Locked",
-          geolocation: [2.39636,48.87539]
+          geolocation: [2.39636, 48.87539]
         }
-      ]      
+      ]
     } else {
-      this.benchList = (await ApiClient.getBenchList(fieldToFetch)).map(
-        entry => ({... entry})
-      )
+      // this.benchList = (await ApiClient.getBenchList(fieldToFetch)).map(
+      //   entry => ({... entry})
+      // )
     }
-    
+
   }
 }
 

--- a/client/src/store/Store.ts
+++ b/client/src/store/Store.ts
@@ -1,88 +1,63 @@
 import { action, observable } from 'mobx'
-import { ApiBenchReponseRoot, QueryApiBenchReponse, ApiBenchReponseRootTemp, ApiBenchTemp } from '../@types';
+import { ApiBenchReponseRoot, QueryApiBenchReponse, ApiBench } from '../@types';
+import ApiClient from '../ApiClient/ApiClient';
 
 class Store {
   @observable benchList: ApiBenchReponseRoot = []
   @observable benchListTemp: ApiBenchReponseRoot = []
 
-  /**
-   * Recuperer des infos spécifiques
-   * Merge au tableau déjà existant dans le store =>
-   * Ajout des données récuperer sans écrasé les précédentes données
-   */
-
-  @action public fetchBenchList = async (dataToLoad?: string, fieldToFetch?: QueryApiBenchReponse) => {
+  @action public fetchBenchList = async (fieldToFetch: QueryApiBenchReponse) => {
     if (process.env.NODE_ENV === "development") {
 
-      const nameGeoData: ApiBenchReponseRootTemp = [
-        {
-          id: 1,
-          name: "Bench1",
-        },
-        {
-          id: 2,
-          name: "Bench2",
-        },
-        {
-          id: 3,
-          name: "Bench3",
-        }
-      ]
+      const data:ApiBenchReponseRoot  = (await ApiClient.getBenchList(fieldToFetch)).map(
+          entry => ({... entry})
+        )
 
-      const descData: ApiBenchReponseRootTemp = [
-        {
-          id: 1,
-          description: "Desc1",
-        },
-        {
-          id: 2,
-          description: "Desc2",
-        },
-        {
-          id: 3,
-          description: "Desc3",
-        }
-      ]
+      this.benchList = this.mergeById(data);
 
-      let data: ApiBenchReponseRootTemp
-
-      dataToLoad === "nameGeo" ? data = nameGeoData : data = descData
-
-      const mergeById = (array1:ApiBenchReponseRootTemp, array2:ApiBenchReponseRootTemp) =>
-      array1.map(itm => ({
-          ...array2.find((item:any) => (item.id === itm.id) && item),
-          ...itm
-        }));
-
-      this.benchListTemp = mergeById(data, this.benchListTemp);
-
-      this.benchList = [
-        {
-          name: "Bench1",
-          description: "Desc1",
-          lockedDescription: "Locked",
-          geolocation: [2.402, 48.8787]
-        },
-        {
-          name: "Bench2",
-          description: "Desc2",
-          lockedDescription: "Locked",
-          geolocation: [2.40764, 48.87512]
-        },
-        {
-          name: "Bench3",
-          description: "Desc3",
-          lockedDescription: "Locked",
-          geolocation: [2.39636, 48.87539]
-        }
-      ]
-    } else {
-      // this.benchList = (await ApiClient.getBenchList(fieldToFetch)).map(
-      //   entry => ({... entry})
-      // )
+      // this.benchList = [
+      //   {
+      //     id: "1",
+      //     name: "Bench1",
+      //     description: "Desc1",
+      //     lockedDescription: "Locked",
+      //     geolocation: [2.402, 48.8787]
+      //   },
+      //   {
+      //     id: "2",
+      //     name: "Bench2",
+      //     description: "Desc2",
+      //     lockedDescription: "Locked",
+      //     geolocation: [2.40764, 48.87512]
+      //   },
+      //   {
+      //     id: "3",
+      //     name: "Bench3",
+      //     description: "Desc3",
+      //     lockedDescription: "Locked",
+      //     geolocation: [2.39636, 48.87539]
+      //   }
+      // ]
     }
 
   }
+
+  mergeById = (data:ApiBenchReponseRoot) => {
+    let mergedData
+    if (this.benchList.length > 0) {
+      mergedData = this.benchList.map(itm => ({
+        ...data.find((item:ApiBench) =>(
+          (item._id === itm._id))
+          ),
+        ...itm
+      }));
+    } else {
+      mergedData = data
+    }
+
+    return mergedData
+  }
+    
 }
 
 export default new Store()

--- a/client/src/store/Store.ts
+++ b/client/src/store/Store.ts
@@ -1,5 +1,5 @@
 import { action, observable } from 'mobx'
-import { ApiBenchReponseRoot, QueryApiBenchReponse, ApiBench } from '../@types';
+import { ApiBenchReponseRoot, QueryApiBenchReponse, ApiBench, ApiSingleBenchReponseRoot } from '../@types';
 import ApiClient from '../ApiClient/ApiClient';
 
 class Store {
@@ -39,7 +39,12 @@ class Store {
       //   }
       // ]
     }
+  }
 
+  @action public fetchSingleBench = async(benchID:ApiBench["_id"], fieldToFetch: QueryApiBenchReponse) => {
+    const data:ApiSingleBenchReponseRoot = (await ApiClient.getSingleBench(benchID,fieldToFetch))
+
+    this.benchList = this.mergeById([data])
   }
 
   mergeById = (data:ApiBenchReponseRoot) => {


### PR DESCRIPTION
## 📋 Spécifications techniques
- [x]  Refacto de la logique de récupération des données.
Auparavant, `benchList` dans le Store était écrasé à chaque appel à l'API.
Maintenant, les informations de la réponse sont fusionnées et n'écrasent donc plus la valeur précédente de `benchList`.
Cela va permettre de garder en mémoire dans le store les informations au fur et à mesure de la navigation et d'éviter d'éventuelles requêtes si les informations nécessaires à l'affichage d'une page ont déjà été demandées par le passé.

⚠️ La fusion des données se fait avec l'ID des installations, il est donc impératif de demandé l'ID lorsqu'on veut des informations sur des installations. Actuellement, l'id est présent par défaut dans le schéma de requête et n'est pas à renseigner pour éviter l'oubli.


- [x] Sur l'API, une nouvelle méthode (getter) est disponible pour récupérer les informations propre à une seul installation. `singleBench(benchId: ID!): Bench!`
En passant un ID (Type ID côté API et string côté client), on peut récupérer les informations d'une installation.
Les informations recueillies sont ensuite fusionnées à la liste des installations (`benchList`) dans le Store.


On profite de l'avantage de GraphQL en allant chercher seulement les informations nécessaires sur le moment tout en évitant des requêtes réseau inutiles (même si elles sont légères).
