### PR TITLE
:recycle: :art: Updated props naming &  show/hide modal with state

### DIFF
--- a/client/src/components/Modal/Modal.tsx
+++ b/client/src/components/Modal/Modal.tsx
@@ -1,14 +1,14 @@
-import React, { FunctionComponent } from 'react'
-import { observer } from 'mobx-react-lite'
+import React, { FunctionComponent, useState } from 'react'
 import Button, { themes as ButtonThemes } from '../../components/Button/Button'
 import './modal.scss'
+import Classnames from 'classnames'
 
 type Props = {
   className?: string
   modalTitle: string
   textContent: string
   onButtonClick?: any
-  buttonTitle: string
+  buttonLabel: string
 }
 
 const Modal: FunctionComponent<Props> = ({
@@ -16,26 +16,31 @@ const Modal: FunctionComponent<Props> = ({
   modalTitle,
   textContent,
   onButtonClick,
-  buttonTitle,
+  buttonLabel,
 }) => {
   let modal: HTMLDivElement | null = null
+
+  const [isModalOpen, setIsModal] = useState(true)
 
   const clickButton = () => {
     if (onButtonClick) {
       onButtonClick()
     }
     if (modal) {
-      modal.classList.add('hidden')
+      setIsModal(false)
     }
   }
 
   return (
-    <div className="modal" ref={el => (modal = el)}>
+    <div
+      className={Classnames(className, 'modal', { hidden: !isModalOpen })}
+      ref={el => (modal = el)}
+    >
       <h3 className="modal__title">{modalTitle}</h3>
       <p className="modal__text-content">{textContent}</p>
       <Button
         onClick={clickButton}
-        label={buttonTitle}
+        label={buttonLabel}
         theme={ButtonThemes.Blue}
         className={'informations-panel__set-direction-button'}
       />
@@ -43,4 +48,4 @@ const Modal: FunctionComponent<Props> = ({
   )
 }
 
-export default observer(Modal)
+export default Modal

--- a/client/src/components/map/ProtoMap.tsx
+++ b/client/src/components/map/ProtoMap.tsx
@@ -119,7 +119,7 @@ const ProtoMap: FunctionComponent = () => {
         Nous vous proposons de vous diriger vers l’installation la plus proche pour réaliser la performance et débloquer le contenu associé.
         Pour cela nous aurons besoin de votre localisation. 
         "
-        buttonTitle="Démarrer"
+        buttonLabel="Démarrer"
         onButtonClick={initGeoLocate}
       />
       {markers && userLocation && (

--- a/client/src/pages/Components/Components.tsx
+++ b/client/src/pages/Components/Components.tsx
@@ -51,9 +51,11 @@ const Components: FunctionComponent<Props> = ({ show }) => {
         <div className="modal-container">
           <Modal
             modalTitle="Votre parcours commence !"
-            textContent="Nous vous proposons de vous diriger vers l'installation la plus proche
-            pour réaliser la performance et débloquer le contenu associé."
-            buttonTitle="Démarrer"
+            textContent="
+          Nous vous proposons de vous diriger vers l’installation la plus proche pour réaliser la performance et débloquer le contenu associé.
+          Pour cela nous aurons besoin de votre localisation. 
+          "
+            buttonLabel="Démarrer"
           />
         </div>
         <hr />


### PR DESCRIPTION
## 📋 Spécifications techniques
- [x] La props `buttonTItle` a été renommé `buttonLabel`pour plus de cohérence (car le componsant Button) prend en paramètre un label, et non pas un titreà
- [x] La props className est maintenant utilisé
- [x] L'affichage ou non de la modal est maintenant géré avec le state. La classe `hidden` est appliquée si `isModalOpen`est égal à `false`
- [x] Le componsant n'est plus wrapper dans un observer car le store n'est pas utilisé dedans