### PR TITLE
Mise à jour des transitions de page

### DIFF
--- a/client/src/components/MapButton/MapButton.tsx
+++ b/client/src/components/MapButton/MapButton.tsx
@@ -29,10 +29,11 @@ const MapButton: FunctionComponent<Props> = ({ className }) => {
   useEffect(() => {
     const tl = new TimelineMax()
     if (ref.current) {
-      tl.to(ref.current, 1, {
+      tl.to(ref.current, 0.3, {
         xPercent: isMapButtonVisible ? -50 : -100,
         yPercent: isMapButtonVisible ? 50 : 100,
         opacity: isMapButtonVisible ? 1 : 0,
+        ease: 'Sine.easeInOut',
       })
     }
   }, [isMapButtonVisible])

--- a/client/src/pages/Admin/Transition.tsx
+++ b/client/src/pages/Admin/Transition.tsx
@@ -15,8 +15,7 @@ const TransitionComponent: FunctionComponent<Props> = ({ show, children }) => {
   // Enter : start
   const onEnter = (node: HTMLElement): void => {
     TweenMax.set(node, {
-      autoAlpha: 0,
-      x: -100,
+      opacity: 0,
     })
   }
 
@@ -26,9 +25,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show, children }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 1,
-      x: 0,
+    tl.to(node, 0.25, {
+      opacity: 1,
+      ease: 'Sine.easeInOut',
     })
   }
 
@@ -38,9 +37,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show, children }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 0,
-      x: 100,
+    tl.to(node, 0.25, {
+      opacity: 0,
+      ease: 'Sine.easeInOut',
     })
   }
 

--- a/client/src/pages/Components/Transition.tsx
+++ b/client/src/pages/Components/Transition.tsx
@@ -14,8 +14,7 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
   // Enter : start
   const onEnter = (node: HTMLElement): void => {
     TweenMax.set(node, {
-      autoAlpha: 0,
-      x: -100,
+      opacity: 0,
     })
   }
 
@@ -25,9 +24,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 1,
-      x: 0,
+    tl.to(node, 0.25, {
+      opacity: 1,
+      ease: 'Sine.easeInOut',
     })
   }
 
@@ -37,9 +36,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 0,
-      x: 100,
+    tl.to(node, 0.25, {
+      opacity: 0,
+      ease: 'Sine.easeInOut',
     })
   }
 

--- a/client/src/pages/Finish/Transition.tsx
+++ b/client/src/pages/Finish/Transition.tsx
@@ -14,8 +14,7 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
   // Enter : start
   const onEnter = (node: HTMLElement): void => {
     TweenMax.set(node, {
-      autoAlpha: 0,
-      x: -100,
+      opacity: 0,
     })
   }
 
@@ -25,9 +24,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 1,
-      x: 0,
+    tl.to(node, 0.25, {
+      opacity: 1,
+      ease: 'Sine.easeInOut',
     })
   }
 
@@ -37,9 +36,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 0,
-      x: 100,
+    tl.to(node, 0.25, {
+      opacity: 0,
+      ease: 'Sine.easeInOut',
     })
   }
 

--- a/client/src/pages/Home/Transition.tsx
+++ b/client/src/pages/Home/Transition.tsx
@@ -14,8 +14,7 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
   // Enter : start
   const onEnter = (node: HTMLElement): void => {
     TweenMax.set(node, {
-      autoAlpha: 0,
-      x: -100,
+      opacity: 0,
     })
   }
 
@@ -25,9 +24,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 1,
-      x: 0,
+    tl.to(node, 0.25, {
+      opacity: 1,
+      ease: 'Sine.easeInOut',
     })
   }
 
@@ -37,9 +36,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 0,
-      x: 100,
+    tl.to(node, 0.25, {
+      opacity: 0,
+      ease: 'Sine.easeInOut',
     })
   }
 

--- a/client/src/pages/Installation/Installation.tsx
+++ b/client/src/pages/Installation/Installation.tsx
@@ -34,6 +34,11 @@ const Installation: FunctionComponent<Props> = ({ match, history }) => {
       getInstallationInformation()
     }
     setIsMapButtonVisible(true)
+
+    return () => {
+      ScrollMagicController.destroyScrollMagicScenes()
+      window.scrollTo(0, 0)
+    }
   }, [])
 
   const getInstallationInformation = async () => {

--- a/client/src/pages/Installation/ScrollMagicController.ts
+++ b/client/src/pages/Installation/ScrollMagicController.ts
@@ -7,6 +7,12 @@ import ScrollMagicStore from '../../store/ScrollMagicStore'
 import { NavigationStore } from '../../store'
 
 class ScrollMagicController {
+  scenes: ScrollMagic.Scene[]
+
+  constructor() {
+    this.scenes = []
+  }
+
   public initController = () => {
     const { setScrollProgressFirstPart } = ScrollMagicStore
     const { setScrollProgression } = NavigationStore
@@ -70,6 +76,7 @@ class ScrollMagicController {
       .setPin('.page-installation__part1')
       // .addIndicators({ name: 'Pin' })
       .addTo(controller)
+    this.scenes.push(scenePart1Pin)
 
     const scenePresentationText = new ScrollMagic.Scene({
       duration: 1000,
@@ -78,6 +85,7 @@ class ScrollMagicController {
       .setTween(tweenPresentationText)
       // .addIndicators({ name: 'Animation presentation translate text' })
       .addTo(controller)
+    this.scenes.push(scenePresentationText)
 
     scenePresentationText.on('progress', (event: any) => {
       setScrollProgressFirstPart(event.progress)
@@ -91,6 +99,7 @@ class ScrollMagicController {
       .setTween(tweenPresentationFade)
       // .addIndicators({ name: 'Animation presentation fade' })
       .addTo(controller)
+    this.scenes.push(scenePresentationFade)
 
     const sceneTestimony = new ScrollMagic.Scene({
       duration: 400,
@@ -109,6 +118,7 @@ class ScrollMagicController {
       .setTween(tweenTestimonyTextFade)
       // .addIndicators({ name: 'Animation testimony text' })
       .addTo(controller)
+    this.scenes.push(sceneTestimonyTextFade)
 
     const sceneTestimonyTextTranslate = new ScrollMagic.Scene({
       duration: 1000,
@@ -118,12 +128,12 @@ class ScrollMagicController {
       .setTween(tweenTestimonyTextTranslate)
       // .addIndicators({ name: 'Animation testimony translate text' })
       .addTo(controller)
-
+    this.scenes.push(sceneTestimonyTextTranslate)
     /**
      * PART 2
      */
 
-    // TWENNS
+    // TWEENS
     const tweenMapButtonColor = new TimelineMax()
       .to(
         '.map-button',
@@ -152,6 +162,7 @@ class ScrollMagicController {
       .setPin('.page-installation__part2')
       // .addIndicators({ name: 'Pin 2' })
       .addTo(controller)
+    this.scenes.push(scenePart2Pin)
 
     const part2Height = document
       .querySelector('.page-installation__part2')!
@@ -165,14 +176,22 @@ class ScrollMagicController {
       .setTween(tweenMapButtonColor)
       // .addIndicators({ name: 'Transition Map button color' })
       .addTo(controller)
+    this.scenes.push(transitionMapButtonColor)
 
     const scenePage = new ScrollMagic.Scene({
       duration: part1Height + part2Height,
       triggerHook: 0,
     }).addTo(controller)
+    this.scenes.push(scenePage)
 
     scenePage.on('progress', (event: any) => {
       setScrollProgression(event.progress)
+    })
+  }
+
+  public destroyScrollMagicScenes = () => {
+    this.scenes.forEach(scene => {
+      scene.destroy(true)
     })
   }
 }

--- a/client/src/pages/Installation/Transition.tsx
+++ b/client/src/pages/Installation/Transition.tsx
@@ -18,7 +18,6 @@ const TransitionComponent: FunctionComponent<Props> = ({
   // Enter : start
   const onEnter = (node: HTMLElement) => {
     TweenMax.set(node, {
-      autoAlpha: 0,
       opacity: 0,
     })
   }
@@ -29,9 +28,9 @@ const TransitionComponent: FunctionComponent<Props> = ({
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 1,
+    tl.to(node, 0.25, {
       opacity: 1,
+      ease: 'Sine.easeInOut',
     })
   }
 
@@ -41,9 +40,9 @@ const TransitionComponent: FunctionComponent<Props> = ({
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 0,
+    tl.to(node, 0.25, {
       opacity: 0,
+      ease: 'Sine.easeInOut',
     })
   }
 

--- a/client/src/pages/Installation/installation.scss
+++ b/client/src/pages/Installation/installation.scss
@@ -133,7 +133,7 @@
     opacity: 0;
 
     &__player {
-      max-width: $content-width;
+      max-width: 15rem;
       margin: auto;
       display: block;
       margin-bottom: 3rem;

--- a/client/src/pages/Map/Transition.tsx
+++ b/client/src/pages/Map/Transition.tsx
@@ -14,8 +14,7 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
   // Enter : start
   const onEnter = (node: HTMLElement): void => {
     TweenMax.set(node, {
-      autoAlpha: 0,
-      x: -100,
+      opacity: 0,
     })
   }
 
@@ -25,9 +24,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 1,
-      x: 0,
+    tl.to(node, 0.25, {
+      opacity: 1,
+      ease: 'Sine.easeInOut',
     })
   }
 
@@ -37,9 +36,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 0,
-      x: 100,
+    tl.to(node, 0.25, {
+      opacity: 0,
+      ease: 'Sine.easeInOut',
     })
   }
 

--- a/client/src/pages/Twitter/Transition.tsx
+++ b/client/src/pages/Twitter/Transition.tsx
@@ -14,8 +14,7 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
   // Enter : start
   const onEnter = (node: HTMLElement): void => {
     TweenMax.set(node, {
-      autoAlpha: 0,
-      x: -100,
+      opacity: 0,
     })
   }
 
@@ -25,9 +24,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 1,
-      x: 0,
+    tl.to(node, 0.25, {
+      opacity: 1,
+      ease: 'Sine.easeInOut',
     })
   }
 
@@ -37,9 +36,9 @@ const TransitionComponent: FunctionComponent<Props> = ({ show }) => {
       onComplete: done,
     })
 
-    tl.to(node, 1, {
-      autoAlpha: 0,
-      x: 100,
+    tl.to(node, 0.25, {
+      opacity: 0,
+      ease: 'Sine.easeInOut',
     })
   }
 


### PR DESCRIPTION
Close #100 
Close #102 

## 📋 Spécifications techniques
- [x] La transition de page est maintenant un fade
- [x] Changement du timing d'animation du `MapButton`
- [x] Kill des scenes scrollMagic quand le composant `Installation` est démonté
Les scènes doivent être ajouté dans un tableau de scènes `this.scenes` (initialisé dans le constructeur de la class ScollMagicController). On peut ensuite `destroy` automatiquement toutes les scènes d'un controleur avec la méthode `ScrollMagicController.destroyScrollMagicScenes()`