### PR TITLE
Ajout du slug pour les installations

### DIFF
--- a/api/graphql/resolvers/installationList.js
+++ b/api/graphql/resolvers/installationList.js
@@ -35,6 +35,7 @@ module.exports = {
         return {
           ...installation._doc,
           _id: installation.id,
+          slug: installation.slug,
           name: installation.name,
           description: installation.description,
           lockedDescription: installation.lockedDescription,
@@ -58,6 +59,7 @@ module.exports = {
   },
   createInstallation: async args => {
     const installation = new Installation({
+      slug: args.installationInput.slug,
       name: args.installationInput.name,
       description: args.installationInput.description,
       lockedDescription: args.installationInput.lockedDescription,
@@ -105,6 +107,7 @@ module.exports = {
   updateInstallation: async args => {
     var fieldsToUpdate = {};
 
+    if (args.updateInstallationInput.slug) fieldsToUpdate.slug = args.updateInstallationInput.slug
     if (args.updateInstallationInput.name) fieldsToUpdate.name = args.updateInstallationInput.name
     if (args.updateInstallationInput.description) fieldsToUpdate.description = args.updateInstallationInput.description
     if (args.updateInstallationInput.lockedDescription) fieldsToUpdate.lockedDescription = args.updateInstallationInput.lockedDescription

--- a/api/graphql/schema/index.graphql
+++ b/api/graphql/schema/index.graphql
@@ -3,6 +3,7 @@ const { buildSchema } = require('graphql')
 module.exports = buildSchema(`
   type Installation {
     _id: ID!
+    slug: String!
     name: String!
     description: String!
     lockedDescription: String!
@@ -19,6 +20,7 @@ module.exports = buildSchema(`
   }
   
   input InstallationInput {
+    slug: String!
     name: String!
     description: String!
     lockedDescription: String!
@@ -30,6 +32,7 @@ module.exports = buildSchema(`
 
   input UpdateInstallationInput {
     _id: ID!
+    slug: String
     name: String
     description: String
     lockedDescription: String

--- a/api/models/installation.js
+++ b/api/models/installation.js
@@ -2,6 +2,10 @@ const mongoose = require('mongoose')
 const Schema = mongoose.Schema
 
 const installationSchema = new Schema({   
+  slug: {
+    type: String,
+    required: true
+  },
   name: {
     type: String,
     required: true

--- a/client/src/@types/index.d.ts
+++ b/client/src/@types/index.d.ts
@@ -12,6 +12,7 @@ export type Coords = [number, number]
 
 export interface ApiInstallation {
   _id: string
+  slug?: string
   name?: string
   description?: string
   lockedDescription?: string
@@ -24,6 +25,7 @@ export interface ApiInstallation {
 }
 
 export interface queryApiInstallation {
+  slug?: boolean
   name?: boolean
   description?: boolean
   lockedDescription?: boolean
@@ -34,6 +36,7 @@ export interface queryApiInstallation {
 }
 
 export interface createApiInstallation {
+  slug: string
   name: string
   description: string
   lockedDescription: string

--- a/client/src/components/InformationsPanel/InformationsPanel.tsx
+++ b/client/src/components/InformationsPanel/InformationsPanel.tsx
@@ -99,7 +99,7 @@ const InformationsPanel: FunctionComponent<Props> = ({
         <Button
           theme={themes.Blue}
           label="En savoir plus"
-          link={`/installation/${marker.properties._id}`}
+          link={`/installation/${marker.properties.slug}`}
           className="informations-panel__informations--installation__installation-see-more"
         />
       )}

--- a/client/src/components/map/MapController.ts
+++ b/client/src/components/map/MapController.ts
@@ -33,6 +33,7 @@ class MapManager {
           type: 'Feature',
           properties: {
             _id: installation._id,
+            slug: installation.slug,
             name: installation.name,
             description: installation.description,
             focus: 'true',
@@ -47,6 +48,7 @@ class MapManager {
           type: 'Feature',
           properties: {
             _id: installation._id,
+            slug: installation.slug,
             name: installation.name,
             description: installation.description,
             focus: 'false',

--- a/client/src/components/map/ProtoMap.tsx
+++ b/client/src/components/map/ProtoMap.tsx
@@ -18,7 +18,6 @@ import Modal from '../Modal/Modal'
 const ProtoMap: FunctionComponent = () => {
   const { installationList, fetchInstallationList } = InstallationStore
 
-  // const map = useRef<MapboxGlMap | null>(null)
   const directions = useRef(DirectionsManager.initMapboxDirections())
   const geolocate = useRef<GeolocateControl>(GeoLocationManager.initGeolocate())
 

--- a/client/src/config/config.ts
+++ b/client/src/config/config.ts
@@ -39,7 +39,7 @@ export default {
       inNav: true,
     },
     Installation: {
-      path: '/installation/:installationId',
+      path: '/installation/:installationSlug',
       name: 'Installation',
       component: InstallationTransition,
       inNav: false,

--- a/client/src/pages/Admin/Admin.tsx
+++ b/client/src/pages/Admin/Admin.tsx
@@ -31,6 +31,9 @@ class Admin extends Component<Props, stateAdmin> {
       e.preventDefault()
 
       if (this.createInstallationForm) {
+        const slug: string = (this.createInstallationForm.querySelector(
+          '[name="slug"]'
+        ) as HTMLInputElement).value
         const name: string = (this.createInstallationForm.querySelector(
           '[name="name"]'
         ) as HTMLInputElement).value
@@ -54,6 +57,7 @@ class Admin extends Component<Props, stateAdmin> {
         ) as HTMLInputElement).value.split(' ')
 
         if (
+          slug.length > 0 &&
           name.length > 0 &&
           description.length > 0 &&
           lockedDescription.length > 0 &&
@@ -61,6 +65,7 @@ class Admin extends Component<Props, stateAdmin> {
           longitude.length > 0
         ) {
           await ApiClient.createInstallation({
+            slug,
             name,
             description,
             lockedDescription,
@@ -94,6 +99,9 @@ class Admin extends Component<Props, stateAdmin> {
         const id: string = (this.updateInstallationForm.querySelector(
           '[name="id"]'
         ) as HTMLInputElement).value
+        const slug: string = (this.updateInstallationForm.querySelector(
+          '[name="slug"]'
+        ) as HTMLInputElement).value
         const name: string = (this.updateInstallationForm.querySelector(
           '[name="name"]'
         ) as HTMLInputElement).value
@@ -118,6 +126,10 @@ class Admin extends Component<Props, stateAdmin> {
 
         const fieldsToUpdate: ApiInstallation = {
           _id: id,
+        }
+
+        if (slug.length > 0) {
+          fieldsToUpdate.slug = slug
         }
 
         if (name.length > 0) {
@@ -246,6 +258,13 @@ class Admin extends Component<Props, stateAdmin> {
         >
           <input
             type="text"
+            name="slug"
+            placeholder="Slug"
+            required
+            className="admin-panel__form__field"
+          />
+          <input
+            type="text"
             name="name"
             placeholder="Nom"
             required
@@ -308,6 +327,12 @@ class Admin extends Component<Props, stateAdmin> {
             name="id"
             placeholder="ID"
             required
+            className="admin-panel__form__field"
+          />
+          <input
+            type="text"
+            name="slug"
+            placeholder="Slug"
             className="admin-panel__form__field"
           />
           <input

--- a/client/src/store/InstallationStore.ts
+++ b/client/src/store/InstallationStore.ts
@@ -18,6 +18,7 @@ class InstallationStore {
       this.installationList = [
         {
           _id: '1',
+          slug: 'exedros',
           name: 'L’Exedros',
           description:
             'Vestige du 19e siècle, cette sculpture aux courbes parfaites...',
@@ -27,6 +28,7 @@ class InstallationStore {
         },
         {
           _id: '2',
+          slug: 'glissant',
           name: 'Super banc',
           description:
             'Vestige du 19e siècle, cette sculpture aux courbes parfaites...',
@@ -36,6 +38,7 @@ class InstallationStore {
         },
         {
           _id: '3',
+          slug: 'piquant',
           name: 'Ça pique',
           description:
             'Vestige du 19e siècle, cette sculpture aux courbes parfaites...',


### PR DESCRIPTION
Close #128 
## 📋 Spécifications techniques
- [x] Ajout du slug aux installations permettant de générer une URL plus "user friendly".
Auparavant, l'URL d'une installation était généré avec l'ID : `installation/3`. 
Maintenant, l'URL a ce format : `installation/exedros` par exemple
