### PR TITLE
Installation page : split unlocked / locked in different folders

### DIFF
--- a/client/src/pages/Installation/Installation.tsx
+++ b/client/src/pages/Installation/Installation.tsx
@@ -1,27 +1,30 @@
 import React, { FunctionComponent, useEffect, useState } from 'react'
 import { pageProps } from '../types'
 import { InstallationStore, MapStore } from '../../store'
-import './installation.scss'
+import './unlocked/installation-unlocked.scss'
 import { observer } from 'mobx-react-lite'
-import InstallationUnlocked from './InstallationUnlocked'
-import InstallationLocked from './InstallationLocked'
+import InstallationUnlocked from './unlocked/InstallationUnlocked'
+import InstallationLocked from './locked/InstallationLocked'
 
 type Props = pageProps & {}
 
 const Installation: FunctionComponent<Props> = ({ match, history }) => {
   const [installationIdentifier, setInstallationIdentifier] = useState()
 
+  const { isInstallationUnlocked } = InstallationStore
+  const { selectedInstallation } = MapStore
+
   useEffect(() => {
     setInstallationIdentifier(
-      MapStore.selectedInstallation._id
-        ? MapStore.selectedInstallation._id
+      selectedInstallation._id
+        ? selectedInstallation._id
         : match.params.installationSlug
     )
   }, [])
 
   return (
     <>
-      {InstallationStore.isInstallationUnlocked(installationIdentifier) ? (
+      {isInstallationUnlocked(installationIdentifier) ? (
         <InstallationUnlocked match={match} history={history} />
       ) : (
         <InstallationLocked match={match} history={history} />

--- a/client/src/pages/Installation/locked/InstallationLocked.tsx
+++ b/client/src/pages/Installation/locked/InstallationLocked.tsx
@@ -1,10 +1,10 @@
 import React, { FunctionComponent, useEffect, useState } from 'react'
-import { pageProps } from '../types'
-import { InstallationStore } from '../../store'
-import { ApiInstallation } from '../../@types'
-import './installation.scss'
+import { pageProps } from '../../types'
+import { InstallationStore } from '../../../store'
+import { ApiInstallation } from '../../../@types'
+import './installation-locked.scss'
 import { observer } from 'mobx-react-lite'
-import { NavigationStore } from '../../store'
+import { NavigationStore } from '../../../store'
 
 type Props = pageProps & {}
 

--- a/client/src/pages/Installation/locked/installation-locked.scss
+++ b/client/src/pages/Installation/locked/installation-locked.scss
@@ -1,0 +1,31 @@
+@import '../../../assets/styles/global';
+
+.page-installation {
+  background-color: $color-blue;
+  height: 100vh;
+  &--locked {
+    &__presentation {
+      &__title {
+        display: inline-block;
+        margin: 3.5rem 0;
+        width: 100%;
+        color: $color-green;
+        font-size: 4rem;
+        text-align: center;
+        font-family: $font-infini-regular;
+        text-transform: uppercase;
+      }
+
+      &__text-content {
+        text-align: center;
+        max-width: $content-width;
+        padding: 3rem $content-padding 0 $content-padding;
+        margin: auto;
+        font-family: $font-infini-regular;
+        color: $color-pink;
+        font-size: 1.5rem;
+        line-height: 1.3em;
+      }
+    }
+  }
+}

--- a/client/src/pages/Installation/unlocked/InstallationUnlocked.tsx
+++ b/client/src/pages/Installation/unlocked/InstallationUnlocked.tsx
@@ -1,18 +1,20 @@
 import React, { FunctionComponent, useEffect, useState } from 'react'
-import { pageProps } from '../types'
-import { InstallationStore, MapStore } from '../../store'
-import { ApiInstallation } from '../../@types'
-import './installation.scss'
+import { pageProps } from '../../types'
+import { InstallationStore, MapStore } from '../../../store'
+import { ApiInstallation } from '../../../@types'
+import './installation-unlocked.scss'
 import ScrollMagicController from './ScrollMagicController'
-import DummyPlayer from '../../assets/images/dummy_player.png'
-import Button, { themes as buttonThemes } from '../../components/Button/Button'
+import DummyPlayer from './../../../assets/images/dummy_player.png'
+import Button, {
+  themes as buttonThemes,
+} from '../../../components/Button/Button'
 import { observer } from 'mobx-react-lite'
-import { NavigationStore } from '../../store'
-import SpriteAnimation from '../../components/SpriteAnimation/SpriteAnimation'
-import ScrollMagicStore from '../../store/ScrollMagicStore'
-import { animationId } from '../../components/SpriteAnimation/animations'
-import TwitterGallery from '../../components/TwitterGallery/TwitterGallery'
-import config from '../../config/config'
+import { NavigationStore } from '../../../store'
+import SpriteAnimation from '../../../components/SpriteAnimation/SpriteAnimation'
+import ScrollMagicStore from '../../../store/ScrollMagicStore'
+import { animationId } from '../../../components/SpriteAnimation/animations'
+import TwitterGallery from '../../../components/TwitterGallery/TwitterGallery'
+import config from '../../../config/config'
 
 type Props = pageProps & {}
 

--- a/client/src/pages/Installation/unlocked/ScrollMagicController.ts
+++ b/client/src/pages/Installation/unlocked/ScrollMagicController.ts
@@ -3,8 +3,8 @@ import { TimelineMax } from 'gsap'
 import ScrollMagic from 'scrollmagic'
 import 'animation.gsap'
 import 'debug.addIndicators'
-import ScrollMagicStore from '../../store/ScrollMagicStore'
-import { NavigationStore } from '../../store'
+import ScrollMagicStore from '../../../store/ScrollMagicStore'
+import { NavigationStore } from '../../../store'
 
 class ScrollMagicController {
   scenes: ScrollMagic.Scene[]

--- a/client/src/pages/Installation/unlocked/installation-unlocked.scss
+++ b/client/src/pages/Installation/unlocked/installation-unlocked.scss
@@ -1,34 +1,8 @@
-@import '../../assets/styles/global';
+@import '../../../assets/styles/global';
 
 .page-installation {
   background-color: $color-blue;
   height: 100vh;
-
-  &--locked {
-    &__presentation {
-      &__title {
-        display: inline-block;
-        margin: 3.5rem 0;
-        width: 100%;
-        color: $color-green;
-        font-size: 4rem;
-        text-align: center;
-        font-family: $font-infini-regular;
-        text-transform: uppercase;
-      }
-
-      &__text-content {
-        text-align: center;
-        max-width: $content-width;
-        padding: 3rem $content-padding 0 $content-padding;
-        margin: auto;
-        font-family: $font-infini-regular;
-        color: $color-pink;
-        font-size: 1.5rem;
-        line-height: 1.3em;
-      }
-    }
-  }
 
   &__wrapper {
     height: 100%;


### PR DESCRIPTION
Close #148 

## 📋 Spécifications techniques
- séparation des composants `installationLocked` et `installationUnlocked` dans 2 dossiers différents avec leur propres styles et in fine ils pourront également avoir leur propre logique de transition
