### PR TITLE
Fix/general layout

### DIFF
--- a/client/src/components/InformationsPanel/InformationsPanel.tsx
+++ b/client/src/components/InformationsPanel/InformationsPanel.tsx
@@ -90,7 +90,7 @@ const InformationsPanel: FunctionComponent<Props> = ({
         open: isInformationsPanelOpen,
       })}
     >
-      {travelTime && travelTime > 0 && isCurrentTargetMatching && (
+      {travelTime > 0 && isCurrentTargetMatching && (
         <div className="informations-panel__direction-informations">
           <WalkIco className="informations-panel__direction-informations__walk-ico" />
           <span className="informations-panel__direction-informations__direction-duration">

--- a/client/src/components/map/ProtoMap.tsx
+++ b/client/src/components/map/ProtoMap.tsx
@@ -193,7 +193,7 @@ const ProtoMap: FunctionComponent<Props> = ({ match, history }) => {
   }, [tempUserLocation])
 
   useEffect(() => {
-    if (isTourStarted) {
+    if (isTourStarted && userLocation) {
       DirectionsController.setPathToInstallation(
         directions.current,
         featureCoords(selectedMarker),
@@ -274,7 +274,6 @@ const ProtoMap: FunctionComponent<Props> = ({ match, history }) => {
         }
       })
       setTargetInstallationSlug(MapStore.targetInstallation.slug)
-      setIsTourStarted(true)
     }
   }, [
     map,

--- a/client/src/components/map/ProtoMap.tsx
+++ b/client/src/components/map/ProtoMap.tsx
@@ -158,10 +158,10 @@ const ProtoMap: FunctionComponent<Props> = ({ match, history }) => {
       })
 
       directions.current.on('route', (e: EventData) => {
-        // // Returned value is in secondes => conversion to minutes
+        // Returned value is in secondes => conversion to minutes
         setTravelTime(Math.floor(e.route[0].duration / 60))
 
-        // // Returned value is in meters => conversion to km
+        // Returned value is in meters => conversion to km
         setTravelDistance((e.route[0].distance / 1000).toFixed(2))
       })
 
@@ -176,6 +176,7 @@ const ProtoMap: FunctionComponent<Props> = ({ match, history }) => {
     markers,
     mapStylesLoaded,
     isGeolocationPermissionGranted,
+    userLocation,
   ])
 
   useEffect(() => {
@@ -297,6 +298,11 @@ const ProtoMap: FunctionComponent<Props> = ({ match, history }) => {
         featureCoords(selectedMarker),
         userLocation
       )
+
+      MapStore.setTargetInstallation(selectedMarker.properties)
+      setTargetInstallationSlug(MapStore.targetInstallation.slug)
+      setIsTourStarted(true)
+      TweenMax.set('.informations-panel', { className: '-=open' })
       setCalculatePathFromAnotherPage(false)
     }
   }, [

--- a/client/src/components/map/ProtoMap.tsx
+++ b/client/src/components/map/ProtoMap.tsx
@@ -16,6 +16,7 @@ import { featureCoords } from '../../utils/map'
 import Modal from '../Modal/Modal'
 import { pageProps } from '../../pages/types'
 import { Feature } from 'geojson'
+import { TweenMax } from 'gsap'
 
 type Props = pageProps & {}
 
@@ -237,6 +238,7 @@ const ProtoMap: FunctionComponent<Props> = ({ match, history }) => {
     MapStore.setTargetInstallation(selectedMarker.properties)
     setTargetInstallationSlug(MapStore.targetInstallation.slug)
     setIsTourStarted(true)
+    TweenMax.set('.informations-panel', { className: '-=open' })
   }
 
   useEffect(() => {

--- a/client/src/components/map/ProtoMap.tsx
+++ b/client/src/components/map/ProtoMap.tsx
@@ -209,7 +209,11 @@ const ProtoMap: FunctionComponent<Props> = ({ match, history }) => {
   }, [travelDistance])
 
   useEffect(() => {
-    if (!MapStore.isInformationsPanelOpen && selectedMarker) {
+    if (
+      !MapStore.isInformationsPanelOpen &&
+      selectedMarker &&
+      selectedMarker._geometry
+    ) {
       map.flyTo({ center: selectedMarker._geometry.coordinates })
     }
   }, [MapStore.isInformationsPanelOpen, selectedMarker])

--- a/client/src/pages/Finish/Finish.tsx
+++ b/client/src/pages/Finish/Finish.tsx
@@ -38,11 +38,7 @@ const Finish: FunctionComponent<Props> = ({ match }) => {
     }
 
     getInstallationList()
-  })
-
-  useEffect(() => {
-    console.log(installationList.length)
-  }, [installationList.length])
+  }, [])
 
   const wording = {
     0: "Il semblerait que tu n'aies pas encore signé de pétition.",

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -183,11 +183,11 @@ const Home: FunctionComponent<Props> = ({ match }) => {
       {isSplashscreenCompleted && (
         <div
           className="page-home__containers-wrapper"
-          style={{ maxHeight: windowHeight }}
+          style={{ maxHeight: windowHeight - getHeaderHeight() }}
         >
           <div
             className="page-home__containers-wrapper__container-1"
-            style={{ height: windowHeight }}
+            style={{ height: windowHeight - getHeaderHeight() }}
           >
             <p className="page-home__containers-wrapper__container-1__title">
               UNE EXPERIENCE
@@ -208,7 +208,7 @@ const Home: FunctionComponent<Props> = ({ match }) => {
           <div
             ref={refContainer}
             className="page-home__containers-wrapper__container-2"
-            style={{ height: windowHeight }}
+            style={{ height: windowHeight - getHeaderHeight() }}
           >
             <p className="page-home__containers-wrapper__container-2__title">
               COMMENT PARTICIPER ?

--- a/client/src/pages/Home/home.scss
+++ b/client/src/pages/Home/home.scss
@@ -3,8 +3,6 @@
 .page-home {
   overflow: hidden;
   &__containers-wrapper {
-    padding: 4.25rem;
-
     &__container-2 {
       &__button {
         width: max-content;

--- a/client/src/pages/Installation/locked/InstallationLocked.tsx
+++ b/client/src/pages/Installation/locked/InstallationLocked.tsx
@@ -75,11 +75,11 @@ const Installation: FunctionComponent<Props> = ({ match, history }) => {
   }
 
   const onButtonClick = () => {
-    MapStore.setCalculatePathFromAnotherPage(true)
     const target = InstallationStore.getInstallationBySlug(
       match.params.installationSlug
     )
     MapStore.setTargetInstallation(target)
+    MapStore.setCalculatePathFromAnotherPage(true)
   }
 
   const windowHeight = useWindowSize().height

--- a/client/src/pages/Installation/locked/InstallationLocked.tsx
+++ b/client/src/pages/Installation/locked/InstallationLocked.tsx
@@ -93,14 +93,16 @@ const Installation: FunctionComponent<Props> = ({ match, history }) => {
               {installation.name}
             </p>
 
-            <SpriteAnimation
-              className={
-                'page-installation--locked__wrapper__part--first-part__presentation__installation-sketch'
-              }
-              progression={1}
-              animationID={animationId.bancMetro}
-              onInstance={handleSpriteAnimationInstance}
-            />
+            {installation && installation.slug && (
+              <SpriteAnimation
+                className={
+                  'page-installation--locked__wrapper__part--first-part__presentation__installation-sketch'
+                }
+                progression={1}
+                animationID={installation.slug}
+                onInstance={handleSpriteAnimationInstance}
+              />
+            )}
 
             <div className="page-installation--locked__wrapper__part--first-part__presentation__description">
               <p

--- a/client/src/store/InstallationStore.ts
+++ b/client/src/store/InstallationStore.ts
@@ -10,7 +10,7 @@ import ApiClient from '../ApiClient/ApiClient'
 class InstallationStore {
   @observable installationList: ApiInstallationReponseRoot = []
   @observable installationListTemp: ApiInstallationReponseRoot = []
-  @observable unlockedInstallations: string[] = ['3']
+  @observable unlockedInstallations: string[] = []
 
   // TODO : required ?
   @observable currentInstallationId: string | null = null

--- a/client/src/store/InstallationStore.ts
+++ b/client/src/store/InstallationStore.ts
@@ -238,7 +238,7 @@ class InstallationStore {
   @action public addUnlockedInstallation = (
     installationID: ApiInstallation['_id']
   ) => {
-    this.unlockedInstallations.push(installationID!)
+    this.unlockedInstallations.push(installationID)
 
     if (!this.isInstallationInLocalStorage(installationID)) {
       localStorage.setItem(
@@ -255,7 +255,9 @@ class InstallationStore {
 
     if (storageUnlockedInstallations) {
       JSON.parse(storageUnlockedInstallations).forEach((id: string) => {
-        this.addUnlockedInstallation(id)
+        if (!this.isInstallationUnlocked(id)) {
+          this.addUnlockedInstallation(id)
+        }
       })
     }
   }


### PR DESCRIPTION
## 📋 Spécifications techniques
<!-- Décris en gros ce que t'as fait dans cette PR dans une liste à puce claire et concise -->
- [x] Amélioration du callage du texte sur la home
- [x] Fermeture du panneau d'informations quand on chemin est tracé
- [x] Le chemin est retracé tout les 5 metres lorsque l'utilisateur a défini un trajet et bouge
- [x] Fix d'un bug quand l'utilisateur traçais un trajet depuis une page externe à la page map
- [x] Mise à jour des sprites dynamique dans la page locked
- [x] Fix d'un problème de gestion des installations unlocked. Il manquait une condition et une installation pouvait être ajouté 2 fois dans le tableau des installations débloquées. Ca produisait un décalage sur la page Progress puisqu'on détectait 2 installation fini alors qu'en réalité il n'y en avait qu'une.
- [x] On n'affiche plus le temps de trajet si il est égal à 0